### PR TITLE
Used fully qualified T-prefixed exception names, fixed TODO comment generation, and whitespace fixes

### DIFF
--- a/src/Exceptional/Highlightings/ExceptionNotDocumentedHighlighting.cs
+++ b/src/Exceptional/Highlightings/ExceptionNotDocumentedHighlighting.cs
@@ -41,7 +41,7 @@ namespace ReSharper.Exceptional.Highlightings
             get
             {
                 var exceptionType = ThrownException.ExceptionType;
-                var exceptionTypeName = exceptionType != null ? exceptionType.GetClrName().ShortName : "[NOT RESOLVED]";
+                var exceptionTypeName = exceptionType != null ? exceptionType.GetClrName().FullName : "[NOT RESOLVED]";
                 return String.Format(Resources.HighlightNotDocumentedExceptions, exceptionTypeName);
             }
         }

--- a/src/Exceptional/Highlightings/ExceptionNotDocumentedOptionalHighlighting.cs
+++ b/src/Exceptional/Highlightings/ExceptionNotDocumentedOptionalHighlighting.cs
@@ -44,7 +44,7 @@ namespace ReSharper.Exceptional.Highlightings
             get
             {
                 var exceptionType = ThrownException.ExceptionType;
-                var exceptionTypeName = exceptionType != null ? exceptionType.GetClrName().ShortName : "[NOT RESOLVED]";
+                var exceptionTypeName = exceptionType != null ? exceptionType.GetClrName().FullName : "[NOT RESOLVED]";
                 return Constants.OptionalPrefix + String.Format(Resources.HighlightNotDocumentedExceptions, exceptionTypeName);
             }
         }

--- a/src/Exceptional/Highlightings/ExceptionNotThrownHighlighting.cs
+++ b/src/Exceptional/Highlightings/ExceptionNotThrownHighlighting.cs
@@ -38,7 +38,7 @@ namespace ReSharper.Exceptional.Highlightings
         {
             get
             {
-                return String.Format(Resources.HighlightNotThrownDocumentedExceptions, ExceptionDocumentation.ExceptionType.GetClrName().ShortName);
+                return String.Format(Resources.HighlightNotThrownDocumentedExceptions, ExceptionDocumentation.ExceptionType.GetClrName().FullName);
             }
         }
     }

--- a/src/Exceptional/Highlightings/ExceptionNotThrownOptionalHighlighting.cs
+++ b/src/Exceptional/Highlightings/ExceptionNotThrownOptionalHighlighting.cs
@@ -42,7 +42,7 @@ namespace ReSharper.Exceptional.Highlightings
             get
             {
                 return Constants.OptionalPrefix + String.Format(
-                    Resources.HighlightNotThrownDocumentedExceptions, ExceptionDocumentation.ExceptionType.GetClrName().ShortName);
+                    Resources.HighlightNotThrownDocumentedExceptions, ExceptionDocumentation.ExceptionType.GetClrName().FullName);
             }
         }
     }

--- a/src/Exceptional/Models/DocCommentBlockModel.cs
+++ b/src/Exceptional/Models/DocCommentBlockModel.cs
@@ -68,15 +68,15 @@ namespace ReSharper.Exceptional.Models
                 exceptionDescription = Regex.Replace(exceptionDescription, "<paramref name=\"(.*?)\"/>", m => m.Groups[1].Value);
 
             var exceptionDocumentation = string.IsNullOrEmpty(exceptionDescription)
-                ? string.Format("<exception cref=\"{0}\">" + Constants.ExceptionDescriptionMarker + ".</exception>{1}", thrownException.ExceptionType.GetClrName().ShortName, Environment.NewLine)
-                : string.Format("<exception cref=\"{0}\">{1}</exception>{2}", thrownException.ExceptionType.GetClrName().ShortName, exceptionDescription, Environment.NewLine);
+                ? string.Format("<exception cref=\"T:{0}\">" + Constants.ExceptionDescriptionMarker + ".</exception>{1}", thrownException.ExceptionType.GetClrName().FullName, Environment.NewLine)
+                : string.Format("<exception cref=\"T:{0}\">{1}</exception>{2}", thrownException.ExceptionType.GetClrName().FullName, exceptionDescription, Environment.NewLine);
 
             if (thrownException.ExceptionsOrigin.ContainingBlock is AccessorDeclarationModel)
             {
                 var accessor = ((AccessorDeclarationModel)thrownException.ExceptionsOrigin.ContainingBlock).Node.NameIdentifier.Name;
                 exceptionDocumentation = string.IsNullOrEmpty(exceptionDescription)
-                    ? string.Format("<exception cref=\"{0}\" accessor=\"{1}\">" + Constants.ExceptionDescriptionMarker + ".</exception>{2}", thrownException.ExceptionType.GetClrName().ShortName, accessor, Environment.NewLine)
-                    : string.Format("<exception cref=\"{0}\" accessor=\"{1}\">{2}</exception>{3}", thrownException.ExceptionType.GetClrName().ShortName, accessor, exceptionDescription, Environment.NewLine);
+                    ? string.Format("<exception cref=\"T:{0}\" accessor=\"{1}\">" + Constants.ExceptionDescriptionMarker + ".</exception>{2}", thrownException.ExceptionType.GetClrName().FullName, accessor, Environment.NewLine)
+                    : string.Format("<exception cref=\"T:{0}\" accessor=\"{1}\">{2}</exception>{3}", thrownException.ExceptionType.GetClrName().FullName, accessor, exceptionDescription, Environment.NewLine);
             }
 
             ChangeDocumentation(_documentationText + "\n" + exceptionDocumentation);

--- a/src/Exceptional/Models/DocCommentBlockModel.cs
+++ b/src/Exceptional/Models/DocCommentBlockModel.cs
@@ -57,15 +57,15 @@ namespace ReSharper.Exceptional.Models
             if (thrownException.ExceptionType == null)
                 return null;
 
-            var exceptionDescription = thrownException.ExceptionDescription;
+            var exceptionDescription = thrownException.ExceptionDescription.Trim();
 
             if (thrownException.ExceptionsOrigin is ThrowStatementModel)
             {
                 if (thrownException.ExceptionType.GetClrName().FullName == "System.ArgumentNullException")
-                    exceptionDescription = ArgumentNullExceptionDescription.CreateFrom(thrownException).GetDescription();
+                    exceptionDescription = ArgumentNullExceptionDescription.CreateFrom(thrownException).GetDescription().Trim();
             }
             else
-                exceptionDescription = Regex.Replace(exceptionDescription, "<paramref name=\"(.*?)\"/>", m => m.Groups[1].Value);
+                exceptionDescription = Regex.Replace(exceptionDescription, "<paramref name=\"(.*?)\"/>", m => m.Groups[1].Value).Trim();
 
             var exceptionDocumentation = string.IsNullOrEmpty(exceptionDescription)
                 ? string.Format("<exception cref=\"T:{0}\">" + Constants.ExceptionDescriptionMarker + ".</exception>{1}", thrownException.ExceptionType.GetClrName().FullName, Environment.NewLine)

--- a/src/Exceptional/Models/ExceptionDocCommentModel.cs
+++ b/src/Exceptional/Models/ExceptionDocCommentModel.cs
@@ -94,7 +94,7 @@ namespace ReSharper.Exceptional.Models
             var textRange = documentRange.TextRange;
 
             // TODO: Improve range finding
-            var tagStart = "<exception cref=\"T:";
+            var tagStart = "<exception cref=\"";
             var xml = tagStart + ExceptionTypeName + "\"";
             if (Accessor != null)
                 xml += " accessor=\"" + Accessor + "\"";

--- a/src/Exceptional/Models/ExceptionDocCommentModel.cs
+++ b/src/Exceptional/Models/ExceptionDocCommentModel.cs
@@ -94,7 +94,7 @@ namespace ReSharper.Exceptional.Models
             var textRange = documentRange.TextRange;
 
             // TODO: Improve range finding
-            var tagStart = "<exception cref=\"";
+            var tagStart = "<exception cref=\"T:";
             var xml = tagStart + ExceptionTypeName + "\"";
             if (Accessor != null)
                 xml += " accessor=\"" + Accessor + "\"";

--- a/src/Exceptional/QuickFixes/AddExceptionDocumentationFix.cs
+++ b/src/Exceptional/QuickFixes/AddExceptionDocumentationFix.cs
@@ -65,7 +65,7 @@ namespace ReSharper.Exceptional.QuickFixes
                 string.IsNullOrEmpty(insertedExceptionModel.ExceptionDescription) ||
                 insertedExceptionModel.ExceptionDescription.Contains("[MARKER]");
 
-            var exceptionDescription = copyExceptionDescription ? "Condition" : insertedExceptionModel.ExceptionDescription;
+            var exceptionDescription = copyExceptionDescription ? "Condition" : insertedExceptionModel.ExceptionDescription.Trim();
 
             var nameSuggestionsExpression = new NameSuggestionsExpression(new[] {exceptionDescription});
             var field = new TemplateField("name", nameSuggestionsExpression, 0);

--- a/src/Exceptional/QuickFixes/AddExceptionDocumentationFix.cs
+++ b/src/Exceptional/QuickFixes/AddExceptionDocumentationFix.cs
@@ -40,7 +40,7 @@ namespace ReSharper.Exceptional.QuickFixes
             get
             {
                 return String.Format(Resources.QuickFixInsertExceptionDocumentation,
-                    Error.ThrownException.ExceptionType.GetClrName().ShortName);
+                    Error.ThrownException.ExceptionType.GetClrName().FullName);
             }
         }
 

--- a/src/Exceptional/QuickFixes/CatchExceptionFix.cs
+++ b/src/Exceptional/QuickFixes/CatchExceptionFix.cs
@@ -26,7 +26,7 @@ namespace ReSharper.Exceptional.QuickFixes
 
         public override string Text
         {
-            get { return String.Format(Resources.QuickFixCatchException, Error.ThrownException.ExceptionType.GetClrName().ShortName); }
+            get { return String.Format(Resources.QuickFixCatchException, Error.ThrownException.ExceptionType.GetClrName().FullName); }
         }
 
         protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)

--- a/src/Exceptional/Utilities/CodeElementFactory.cs
+++ b/src/Exceptional/Utilities/CodeElementFactory.cs
@@ -110,8 +110,8 @@ namespace ReSharper.Exceptional.Utilities
         /// <returns>The try statement. </returns>
         public ITryStatement CreateTryStatement(IDeclaredType exceptionType, string exceptionVariableName, ITreeNode context)
         {
-            var tryStatement = _factory.CreateStatement("try {} catch($0 $1) {}",
-                exceptionType.GetClrName().FullName, exceptionVariableName) as ITryStatement;
+            var tryStatement = _factory.CreateStatement("try {} catch($0 $1) {$2    // TODO: Handle the $0 $2}",
+                exceptionType.GetClrName().FullName, exceptionVariableName, Environment.NewLine) as ITryStatement;
             if (tryStatement == null)
                 return null;
 

--- a/src/Exceptional/Utilities/CodeElementFactory.cs
+++ b/src/Exceptional/Utilities/CodeElementFactory.cs
@@ -77,7 +77,7 @@ namespace ReSharper.Exceptional.Utilities
             if (catchBody == null)
             {
                 catchBody = _factory.CreateBlock("{$1    // TODO: Handle the $0 $1}",
-                    exceptionType.GetClrName().ShortName, Environment.NewLine);
+                    exceptionType.GetClrName().FullName, Environment.NewLine);
             }
 
             if (exceptionType != null)
@@ -111,7 +111,7 @@ namespace ReSharper.Exceptional.Utilities
         public ITryStatement CreateTryStatement(IDeclaredType exceptionType, string exceptionVariableName, ITreeNode context)
         {
             var tryStatement = _factory.CreateStatement("try {} catch($0 $1) {}", 
-                exceptionType.GetClrName().ShortName, exceptionVariableName) as ITryStatement;
+                exceptionType.GetClrName().FullName, exceptionVariableName) as ITryStatement;
             if (tryStatement == null) 
                 return null;
 

--- a/src/Exceptional/Utilities/CodeElementFactory.cs
+++ b/src/Exceptional/Utilities/CodeElementFactory.cs
@@ -24,15 +24,15 @@ namespace ReSharper.Exceptional.Utilities
         public ICatchVariableDeclaration CreateCatchVariableDeclarationNode(IDeclaredType exceptionType, ITreeNode context)
         {
             var tryStatement = _factory.CreateStatement("try {} catch(Exception e) {}") as ITryStatement;
-            if (tryStatement == null) 
+            if (tryStatement == null)
                 return null;
 
             var catchClause = tryStatement.Catches[0] as ISpecificCatchClause;
-            if (catchClause == null) 
+            if (catchClause == null)
                 return null;
 
             var exceptionDeclaration = catchClause.ExceptionDeclaration;
-            if (exceptionDeclaration == null) 
+            if (exceptionDeclaration == null)
                 return null;
 
             if (exceptionType != null)
@@ -66,8 +66,8 @@ namespace ReSharper.Exceptional.Utilities
         /// <param name="variableName">A name for catch variable.</param>
         public ISpecificCatchClause CreateSpecificCatchClause(IDeclaredType exceptionType, IBlock catchBody, string variableName)
         {
-            var tryStatement = _factory.CreateStatement("try {} catch(Exception $0) {}", variableName) as ITryStatement;
-            if (tryStatement == null) 
+            var tryStatement = _factory.CreateStatement("try {} catch(Exception $0) {$2    // TODO: Handle the $1 $2}", variableName, exceptionType.GetClrName().FullName, Environment.NewLine) as ITryStatement;
+            if (tryStatement == null)
                 return null;
 
             var catchClause = tryStatement.Catches[0] as ISpecificCatchClause;
@@ -83,7 +83,7 @@ namespace ReSharper.Exceptional.Utilities
             if (exceptionType != null)
             {
                 var exceptionDeclaration = catchClause.ExceptionDeclaration;
-                if (exceptionDeclaration == null) 
+                if (exceptionDeclaration == null)
                     return null;
 
 #if R8
@@ -110,17 +110,17 @@ namespace ReSharper.Exceptional.Utilities
         /// <returns>The try statement. </returns>
         public ITryStatement CreateTryStatement(IDeclaredType exceptionType, string exceptionVariableName, ITreeNode context)
         {
-            var tryStatement = _factory.CreateStatement("try {} catch($0 $1) {}", 
+            var tryStatement = _factory.CreateStatement("try {} catch($0 $1) {}",
                 exceptionType.GetClrName().FullName, exceptionVariableName) as ITryStatement;
-            if (tryStatement == null) 
+            if (tryStatement == null)
                 return null;
 
             var catchClause = tryStatement.Catches[0] as ISpecificCatchClause;
-            if (catchClause == null) 
+            if (catchClause == null)
                 return tryStatement;
 
             var exceptionDeclaration = catchClause.ExceptionDeclaration;
-            if (exceptionDeclaration == null) 
+            if (exceptionDeclaration == null)
                 return tryStatement;
 
 #if R8

--- a/src/Exceptional/Utilities/CodeElementFactory.cs
+++ b/src/Exceptional/Utilities/CodeElementFactory.cs
@@ -66,7 +66,7 @@ namespace ReSharper.Exceptional.Utilities
         /// <param name="variableName">A name for catch variable.</param>
         public ISpecificCatchClause CreateSpecificCatchClause(IDeclaredType exceptionType, IBlock catchBody, string variableName)
         {
-            var tryStatement = _factory.CreateStatement("try {} catch(Exception $0) {$2    // TODO: Handle the $1 $2}", variableName, exceptionType.GetClrName().FullName, Environment.NewLine) as ITryStatement;
+            var tryStatement = _factory.CreateStatement("try {} catch(Exception $0) {$2    // TODO: Handle the $1$2}", variableName, exceptionType.GetClrName().FullName, Environment.NewLine) as ITryStatement;
             if (tryStatement == null)
                 return null;
 
@@ -76,7 +76,7 @@ namespace ReSharper.Exceptional.Utilities
 
             if (catchBody == null)
             {
-                catchBody = _factory.CreateBlock("{$1    // TODO: Handle the $0 $1}",
+                catchBody = _factory.CreateBlock("{$1    // TODO: Handle the $0$1}",
                     exceptionType.GetClrName().FullName, Environment.NewLine);
             }
 
@@ -110,7 +110,7 @@ namespace ReSharper.Exceptional.Utilities
         /// <returns>The try statement. </returns>
         public ITryStatement CreateTryStatement(IDeclaredType exceptionType, string exceptionVariableName, ITreeNode context)
         {
-            var tryStatement = _factory.CreateStatement("try {} catch($0 $1) {$2    // TODO: Handle the $0 $2}",
+            var tryStatement = _factory.CreateStatement("try {} catch($0 $1) {$2    // TODO: Handle the $0$2}",
                 exceptionType.GetClrName().FullName, exceptionVariableName, Environment.NewLine) as ITryStatement;
             if (tryStatement == null)
                 return null;


### PR DESCRIPTION
* Replaced short exception names with fully qualified exception names (this is consistent with the .NET source documentation style and avoids unnecessary underlining/resolution issues)
* Added T prefix to exception crefs for documentation tool support (also consistent with the .NET source documentation style)
* Fixed issues where try-catch builders did not generate TODO comments for the first catch block 
* Removed trailing whitespace in TODO comment templates
* Trimmed leading/trailing whitespace in exception descriptions
