### PR TITLE
RSRP-473772 Error resolving type yWorks.Support.Annotations.CanBeNull…

### DIFF
--- a/src/Exceptional/Models/ArgumentNullExceptionDescription.cs
+++ b/src/Exceptional/Models/ArgumentNullExceptionDescription.cs
@@ -5,7 +5,6 @@ namespace ReSharper.Exceptional.Models
     using System.Linq;
 
     using JetBrains.ReSharper.Psi.CSharp.Tree;
-    using yWorks.Support.Annotations;
 
     /// <summary>
     /// Generates a description to use as the documentation of ArgumentNullException.
@@ -39,7 +38,6 @@ namespace ReSharper.Exceptional.Models
         /// <returns>
         /// A new <see cref="ArgumentNullExceptionDescription"/> instance or <see langword="null"/> when the exception type is not an <see cref="System.ArgumentNullException"/>
         /// </returns>
-        [CanBeNull]
         public static ArgumentNullExceptionDescription CreateFrom(ThrownExceptionModel exception)
         {
             if ("System.ArgumentNullException".Equals(exception.ExceptionType.GetClrName().FullName))

--- a/src/Exceptional/Settings/ExceptionalOptionsPage.cs
+++ b/src/Exceptional/Settings/ExceptionalOptionsPage.cs
@@ -5,7 +5,6 @@ using JetBrains.Application.UI.Options.OptionPages;
 using JetBrains.DataFlow;
 
 using ReSharper.Exceptional.Settings.Views;
-using yWorks.Support.Annotations;
 
 namespace ReSharper.Exceptional.Settings
 {
@@ -14,7 +13,7 @@ namespace ReSharper.Exceptional.Settings
     {
         private const string Pid = "ExceptionalSettings";
 
-        public ExceptionalOptionsPage([NotNull] Lifetime lifetime, OptionsSettingsSmartContext settings, UIApplication environment)
+        public ExceptionalOptionsPage(Lifetime lifetime, OptionsSettingsSmartContext settings, UIApplication environment)
             : base(lifetime, environment, Pid)
         {
             if (lifetime == null)


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/RSRP-473772
yWorks is a third-party library used by ReSharper. It's not a part of ReSharper SDK, despite the fact that some yWorks assemblies could be included in JetBrains.ReSharper.SDK.nupkg. 

The two usages of YWorks NotNull/CanBeNull attributes was removed.
Please use JetBrains ReSharper Annotations if you'd like to annotate our code.
