### PR TITLE
Fixes issue #74.

### DIFF
--- a/src/Exceptional.Playground/Exceptional.Playground.csproj
+++ b/src/Exceptional.Playground/Exceptional.Playground.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Fixed\IgnoreWarningShouldWork.cs" />
     <Compile Include="Fixed\InsertingArgumentNullExceptionDocumentation.cs" />
     <Compile Include="Fixed\NamedArguments.cs" />
+    <Compile Include="Fixed\NameofOperatorShallBeIgnored.cs" />
     <Compile Include="Fixed\NameOfSupportedWithArgumentNullException.cs" />
     <Compile Include="Fixed\WrongWarningOnCtor.cs" />
     <Compile Include="Fixed\PropertyInPropertyInvocation.cs" />

--- a/src/Exceptional.Playground/Fixed/NameofOperatorShallBeIgnored.cs
+++ b/src/Exceptional.Playground/Fixed/NameofOperatorShallBeIgnored.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Exceptional.Playground.Fixed
+{
+    public class NameofOperatorShallBeIgnored : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <exception cref="T:System.InvalidOperationException" accessor="get">Condition.</exception>
+        public string SomeProperty
+        {
+            // no warning shall be shown
+            get => throw new InvalidOperationException("");
+            // no warning shall be shown on SomeProperty, because nameof does not access the getter
+            set => OnPropertyChanged(nameof(SomeProperty));
+        }
+
+        /// <exception cref="T:System.InvalidOperationException" accessor="get">Condition.</exception>
+        public string SomeOtherProperty
+        {
+            // no warning shall be shown
+            get => throw new InvalidOperationException("");
+            set
+            {
+                // warning shall be shown on SomeOtherProperty that InvalidOperationException is not documented
+                if (SomeOtherProperty == value)
+                {
+                    return;
+                }
+            }
+        }
+
+        /// <exception cref="T:System.InvalidOperationException" accessor="get">Condition.</exception>
+        /// <exception cref="T:System.InvalidOperationException" accessor="set">Condition.</exception>
+        public string YetAnotherProperty
+        {
+            // no warning shall be shown
+            get => throw new InvalidOperationException("");
+            set
+            {
+                // no warning shall be shown
+                if (YetAnotherProperty == value)
+                {
+                    return;
+                }
+            }
+        }
+
+        /// <exception cref="T:System.Exception">A delegate callback throws an exception.</exception>
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        private void Test(int i, string a)
+        {
+        }
+    }
+}

--- a/src/Exceptional/Contexts/ProcessContext.cs
+++ b/src/Exceptional/Contexts/ProcessContext.cs
@@ -139,7 +139,8 @@ namespace ReSharper.Exceptional.Contexts
             if (IsValid() == false)
                 return;
 
-            if (invocationExpression == null)
+            var possibleNameofReferenceExpression = invocationExpression?.Parent?.Parent?.Parent?.FirstChild as IReferenceExpression;
+            if (invocationExpression == null || possibleNameofReferenceExpression?.NameIdentifier?.GetText() == "nameof")
                 return;
 
             Logger.Assert(BlockModelsStack.Count > 0, "[Exceptional] There is no block for invocation statement.");


### PR DESCRIPTION
Exceptions thrown by expressions inside nameof-invocations are no longer counted as thrown expressions. Added example to playground to demonstrate the bugfix. 