### PR TITLE
Fix/compiler warnings

### DIFF
--- a/src/Exceptional/Exceptional.csproj
+++ b/src/Exceptional/Exceptional.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ReSharper.Exceptional</RootNamespace>
     <AssemblyName>ReSharper.Exceptional</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/src/Exceptional/Exceptional.csproj
+++ b/src/Exceptional/Exceptional.csproj
@@ -54,6 +54,9 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations">
+      <Version>2019.1.3</Version>
+    </PackageReference>
     <PackageReference Include="JetBrains.Lifetimes">
       <Version>2019.3.0</Version>
     </PackageReference>

--- a/src/Exceptional/Highlightings/EventExceptionNotDocumentedHighlighting.cs
+++ b/src/Exceptional/Highlightings/EventExceptionNotDocumentedHighlighting.cs
@@ -24,7 +24,7 @@ namespace ReSharper.Exceptional.Highlightings
     [ConfigurableSeverityHighlighting(Id, CSharpLanguage.Name)]
     public class EventExceptionNotDocumentedHighlighting : ExceptionNotDocumentedHighlighting
     {
-        public const string Id = "EventExceptionNotDocumented";
+        public new const string Id = "EventExceptionNotDocumented";
 
         /// <summary>Initializes a new instance of the <see cref="EventExceptionNotDocumentedHighlighting"/> class. </summary>
         /// <param name="thrownException">The thrown exception. </param>

--- a/src/Exceptional/Highlightings/ExceptionNotDocumentedHighlighting.cs
+++ b/src/Exceptional/Highlightings/ExceptionNotDocumentedHighlighting.cs
@@ -26,7 +26,7 @@ namespace ReSharper.Exceptional.Highlightings
     [ConfigurableSeverityHighlighting(Id, CSharpLanguage.Name)]
     public class ExceptionNotDocumentedHighlighting : ExceptionNotDocumentedOptionalHighlighting
     {
-        public const string Id = "ExceptionNotDocumented";
+        public new const string Id = "ExceptionNotDocumented";
 
         /// <summary>Initializes a new instance of the <see cref="ExceptionNotDocumentedHighlighting"/> class. </summary>
         /// <param name="thrownException">The thrown exception. </param>

--- a/src/Exceptional/Highlightings/ExceptionNotThrownHighlighting.cs
+++ b/src/Exceptional/Highlightings/ExceptionNotThrownHighlighting.cs
@@ -24,7 +24,7 @@ namespace ReSharper.Exceptional.Highlightings
     [ConfigurableSeverityHighlighting(Id, CSharpLanguage.Name)]
     public class ExceptionNotThrownHighlighting : ExceptionNotThrownOptionalHighlighting
     {
-        public const string Id = "ExceptionNotThrown";
+        public new const string Id = "ExceptionNotThrown";
 
         /// <summary>Initializes a new instance of the <see cref="ExceptionNotThrownHighlighting"/> class. </summary>
         /// <param name="exceptionDocumentation">The exception documentation. </param>

--- a/src/Exceptional/Models/ExceptionsOrigins/ThrowExpressionModel.cs
+++ b/src/Exceptional/Models/ExceptionsOrigins/ThrowExpressionModel.cs
@@ -120,10 +120,10 @@ namespace ReSharper.Exceptional.Models.ExceptionsOrigins
 
             if (objectCreationExpressionNode.Arguments.Count == 0)
             {
-                var messageExpression = CSharpElementFactory.GetInstance(AnalyzeUnit.GetPsiModule())
+                var messageExpression = CSharpElementFactory.GetInstance(AnalyzeUnit.Node)
                     .CreateExpressionAsIs("\"See the inner exception for details.\"");
 
-                var messageArgument = CSharpElementFactory.GetInstance(AnalyzeUnit.GetPsiModule())
+                var messageArgument = CSharpElementFactory.GetInstance(AnalyzeUnit.Node)
                     .CreateArgument(ParameterKind.VALUE, messageExpression);
 
                 messageArgument = objectCreationExpressionNode.AddArgumentAfter(messageArgument, null);
@@ -133,10 +133,10 @@ namespace ReSharper.Exceptional.Models.ExceptionsOrigins
             {
                 var lastArgument = objectCreationExpressionNode.ArgumentList.Arguments.Last();
 
-                var innerExceptionExpression = CSharpElementFactory.GetInstance(AnalyzeUnit.GetPsiModule())
+                var innerExceptionExpression = CSharpElementFactory.GetInstance(AnalyzeUnit.Node)
                     .CreateExpressionAsIs(variableName);
 
-                var innerExpressionArgument = CSharpElementFactory.GetInstance(AnalyzeUnit.GetPsiModule())
+                var innerExpressionArgument = CSharpElementFactory.GetInstance(AnalyzeUnit.Node)
                     .CreateArgument(ParameterKind.VALUE, innerExceptionExpression);
 
                 innerExpressionArgument = objectCreationExpressionNode.AddArgumentAfter(innerExpressionArgument, lastArgument);

--- a/src/Exceptional/Models/ExceptionsOrigins/ThrowStatementModel.cs
+++ b/src/Exceptional/Models/ExceptionsOrigins/ThrowStatementModel.cs
@@ -121,10 +121,10 @@ namespace ReSharper.Exceptional.Models.ExceptionsOrigins
 
             if (objectCreationExpressionNode.Arguments.Count == 0)
             {
-                var messageExpression = CSharpElementFactory.GetInstance(AnalyzeUnit.GetPsiModule())
+                var messageExpression = CSharpElementFactory.GetInstance(AnalyzeUnit.Node)
                     .CreateExpressionAsIs("\"See the inner exception for details.\"");
 
-                var messageArgument = CSharpElementFactory.GetInstance(AnalyzeUnit.GetPsiModule())
+                var messageArgument = CSharpElementFactory.GetInstance(AnalyzeUnit.Node)
                     .CreateArgument(ParameterKind.VALUE, messageExpression);
 
                 messageArgument = objectCreationExpressionNode.AddArgumentAfter(messageArgument, null);
@@ -134,10 +134,10 @@ namespace ReSharper.Exceptional.Models.ExceptionsOrigins
             {
                 var lastArgument = objectCreationExpressionNode.ArgumentList.Arguments.Last();
 
-                var innerExceptionExpression = CSharpElementFactory.GetInstance(AnalyzeUnit.GetPsiModule())
+                var innerExceptionExpression = CSharpElementFactory.GetInstance(AnalyzeUnit.Node)
                     .CreateExpressionAsIs(variableName);
 
-                var innerExpressionArgument = CSharpElementFactory.GetInstance(AnalyzeUnit.GetPsiModule())
+                var innerExpressionArgument = CSharpElementFactory.GetInstance(AnalyzeUnit.Node)
                     .CreateArgument(ParameterKind.VALUE, innerExceptionExpression);
 
                 innerExpressionArgument = objectCreationExpressionNode.AddArgumentAfter(innerExpressionArgument, lastArgument);

--- a/src/Exceptional/Models/TreeElementModelBase.cs
+++ b/src/Exceptional/Models/TreeElementModelBase.cs
@@ -23,7 +23,7 @@ namespace ReSharper.Exceptional.Models
 
         protected CSharpElementFactory GetElementFactory()
         {
-            return CSharpElementFactory.GetInstance(AnalyzeUnit.GetPsiModule());
+            return CSharpElementFactory.GetInstance(AnalyzeUnit.Node);
         }
     }
 }

--- a/src/Exceptional/Utilities/NameFactory.cs
+++ b/src/Exceptional/Utilities/NameFactory.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using JetBrains.Application.Shell;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Naming.Extentions;
@@ -31,7 +33,14 @@ namespace ReSharper.Exceptional.Utilities
             namesCollection.Add(exceptionType, entryOptions);
             namesCollection.Prepare(policy.NamingRule, ScopeKind.Common, new SuggestionOptions());
 
-            return namesCollection.FirstName();
+            try
+            {
+                return namesCollection.GetRoots().FirstOrDefault()?.GetFinalPresentation() ?? String.Empty;
+            }
+            catch (ArgumentNullException)
+            {
+                return String.Empty;
+            }
         }
     }
 }


### PR DESCRIPTION
Update .Net Framework to v4.7.2 to fix warning MSB3275 (Some JetBrains.Platform and JetBrains.PsiFeatures assemblies has indirect depepdencies to assemblies build against .Net Framework v4.7.2)

Fix several `member is obsolete` warnings

Add JetBrains.Annotations as dependency