### PR TITLE
Removev preprocessor directives

### DIFF
--- a/src/Exceptional/Contexts/IProcessContext.cs
+++ b/src/Exceptional/Contexts/IProcessContext.cs
@@ -23,16 +23,8 @@ namespace ReSharper.Exceptional.Contexts
         void Process(ICatchVariableDeclaration catchVariableDeclaration);
         void Process(IReferenceExpression invocationExpression);
         void Process(IObjectCreationExpression objectCreationExpression);
-#if R8
-        void Process(IDocCommentBlockNode docCommentBlockNode);
-#endif
-#if R9 || R10
         void Process(IDocCommentBlock docCommentBlockNode);
-#endif
-#if R2017_1
         void Process(IThrowExpression throwExpression);
-#endif
-
         void EnterAccessor(IAccessorDeclaration accessorDeclarationNode);
         void LeaveAccessor();
     }

--- a/src/Exceptional/Contexts/NullProcessContext.cs
+++ b/src/Exceptional/Contexts/NullProcessContext.cs
@@ -51,22 +51,15 @@ namespace ReSharper.Exceptional.Contexts
 
         }
 
-#if R8
-        public void Process(IDocCommentBlockNode docCommentBlockNode)
-#endif
-#if R9 || R10
         public void Process(IDocCommentBlock docCommentBlockNode)
-#endif
         {
 
         }
 
-#if R2017_1
         public void Process(IThrowExpression throwExpression)
         {
             
         }
-#endif
 
         public void EnterAccessor(IAccessorDeclaration accessorDeclarationNode)
         {

--- a/src/Exceptional/Contexts/ProcessContext.cs
+++ b/src/Exceptional/Contexts/ProcessContext.cs
@@ -169,12 +169,7 @@ namespace ReSharper.Exceptional.Contexts
             return AnalyzeUnit != null;
         }
 
-#if R8
-        public void Process(IDocCommentBlockNode docCommentBlockNode)
-#endif
-#if R9 || R10
         public void Process(IDocCommentBlock docCommentBlockNode)
-#endif
         {
             if (IsValid() == false)
                 return;
@@ -182,7 +177,6 @@ namespace ReSharper.Exceptional.Contexts
             AnalyzeUnit.DocumentationBlock = new DocCommentBlockModel(AnalyzeUnit, docCommentBlockNode);
         }
 
-#if R2017_1
         public void Process(IThrowExpression throwExpression)
         {
             if (IsValid() == false)
@@ -196,7 +190,6 @@ namespace ReSharper.Exceptional.Contexts
             containingBlockModel.ThrownExceptions.Add(
                 new ThrowExpressionModel(AnalyzeUnit, throwExpression, containingBlockModel));
         }
-#endif
 
         public virtual void EnterAccessor(IAccessorDeclaration accessorDeclarationNode)
         {

--- a/src/Exceptional/Exceptional.csproj
+++ b/src/Exceptional/Exceptional.csproj
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;R10 R2017_1</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -26,7 +26,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;R10 R2017_1</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/Exceptional/ExceptionalDaemonStage.cs
+++ b/src/Exceptional/ExceptionalDaemonStage.cs
@@ -1,16 +1,6 @@
 using ReSharper.Exceptional.Settings;
-#if R8
-using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon;
-using JetBrains.ReSharper.Daemon.CSharp.Stages;
-using JetBrains.ReSharper.Psi;
-using JetBrains.ReSharper.Psi.CSharp.Tree;
-#endif
-#if R9 || R10
 using JetBrains.Application.BuildScript.Application.Zones;
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon;
-using JetBrains.ReSharper.Daemon.CSharp.Stages;
 using JetBrains.ReSharper.Feature.Services;
 using JetBrains.ReSharper.Feature.Services.CSharp.Daemon;
 using JetBrains.ReSharper.Feature.Services.Daemon;
@@ -18,16 +8,13 @@ using JetBrains.ReSharper.Feature.Services.Navigation;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
-#endif
 
 namespace ReSharper.Exceptional
 {
-#if R9 || R10
     [ZoneMarker]
     public class ZoneMarker : IPsiLanguageZone, IRequire<ILanguageCSharpZone>, IRequire<ICodeEditingZone>, IRequire<DaemonZone>, IRequire<NavigationZone>
     {
     }
-#endif
 
     internal static class ServiceLocator
     {

--- a/src/Exceptional/ExceptionalDaemonStageProcess.cs
+++ b/src/Exceptional/ExceptionalDaemonStageProcess.cs
@@ -1,16 +1,13 @@
 using JetBrains.DocumentModel;
 
 using System;
-using JetBrains.Application.Progress;
 using JetBrains.Application.Settings;
 using JetBrains.ReSharper.Daemon.CSharp.Stages;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 
-#if R9 || R10
 using JetBrains.ReSharper.Feature.Services.Daemon;
-#endif
 
 namespace ReSharper.Exceptional
 {

--- a/src/Exceptional/ExceptionalRecursiveElementProcessor.cs
+++ b/src/Exceptional/ExceptionalRecursiveElementProcessor.cs
@@ -9,21 +9,14 @@ using ReSharper.Exceptional.Contexts;
 using ReSharper.Exceptional.Models;
 using ReSharper.Exceptional.Settings;
 
-#if R9 || R10
 using JetBrains.ReSharper.Feature.Services.Daemon;
-#endif
 
 namespace ReSharper.Exceptional
 {
     public class ExceptionalRecursiveElementProcessor : IRecursiveElementProcessor
     {
         private readonly CSharpDaemonStageProcessBase _daemonProcess;
-#if R8
-        private readonly List<IDocCommentBlockNode> _eventComments = new List<IDocCommentBlockNode>();
-#endif
-#if R9 || R10
         private readonly List<IDocCommentBlock> _eventComments = new List<IDocCommentBlock>();
-#endif
 
         private IProcessContext _currentContext;
 
@@ -78,20 +71,6 @@ namespace ReSharper.Exceptional
             }
             else if (element is IAccessorDeclaration)
                 _currentContext.EnterAccessor(element as IAccessorDeclaration);
-#if R8
-            else if (element is IDocCommentBlockNode)
-            {
-                if (_currentContext.Model == null || _currentContext.Model.Node == element.Parent)
-                    _currentContext.Process(element as IDocCommentBlockNode);
-                else
-                {
-                    _eventComments.Add((IDocCommentBlockNode)element);
-                    // HACK: Event documentation blocks are processed before event declaration, 
-                    // other documentation blocks are processed after the associated element declaration
-                }
-            }
-#endif
-#if R9 || R10
             else if (element is IDocCommentBlock)
             {
                 if (_currentContext.Model == null || _currentContext.Model.Node == element.Parent)
@@ -103,11 +82,8 @@ namespace ReSharper.Exceptional
                     // other documentation blocks are processed after the associated element declaration
                 }
             }
-#endif
-#if R2017_1
             else if (element is IThrowExpression)
                 _currentContext.Process(element as IThrowExpression);
-#endif
             else if (element is ITryStatement)
                 _currentContext.EnterTryBlock(element as ITryStatement);
             else if (element is ICatchClause)

--- a/src/Exceptional/Highlightings/CatchAllClauseHighlighting.cs
+++ b/src/Exceptional/Highlightings/CatchAllClauseHighlighting.cs
@@ -1,21 +1,14 @@
 using System;
-using JetBrains.ReSharper.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
 using ReSharper.Exceptional;
 using ReSharper.Exceptional.Highlightings;
 
-#if R9 || R10
 using JetBrains.ReSharper.Feature.Services.Daemon;
-#endif
 
 [assembly: RegisterConfigurableSeverity(CatchAllClauseHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
     "Exceptional.CatchAllClause",
     "Exceptional.CatchAllClause",
     Severity.SUGGESTION
-#if !R2016_3 && !R2017_1
-    ,
-    false
-#endif
     )]
 
 

--- a/src/Exceptional/Highlightings/EventExceptionNotDocumentedHighlighting.cs
+++ b/src/Exceptional/Highlightings/EventExceptionNotDocumentedHighlighting.cs
@@ -1,21 +1,14 @@
-using JetBrains.ReSharper.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
 using ReSharper.Exceptional;
 using ReSharper.Exceptional.Highlightings;
 using ReSharper.Exceptional.Models;
 
-#if R9 || R10
 using JetBrains.ReSharper.Feature.Services.Daemon;
-#endif
 
 [assembly: RegisterConfigurableSeverity(EventExceptionNotDocumentedHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
     "Exceptional.EventExceptionNotDocumented",
     "Exceptional.EventExceptionNotDocumented",
     Severity.SUGGESTION
-#if !R2016_3 && !R2017_1
-    ,
-    false
-#endif
     )]
 
 

--- a/src/Exceptional/Highlightings/ExceptionNotDocumentedHighlighting.cs
+++ b/src/Exceptional/Highlightings/ExceptionNotDocumentedHighlighting.cs
@@ -1,23 +1,16 @@
 using System;
-using JetBrains.ReSharper.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
 using ReSharper.Exceptional;
 using ReSharper.Exceptional.Highlightings;
 using ReSharper.Exceptional.Models;
 
-#if R9 || R10
 using JetBrains.ReSharper.Feature.Services.Daemon;
-#endif
 
 
 [assembly: RegisterConfigurableSeverity(ExceptionNotDocumentedHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
     "Exceptional.ExceptionNotDocumented",
     "Exceptional.ExceptionNotDocumented",
     Severity.WARNING
-#if !R2016_3 && !R2017_1
-    ,
-    false
-#endif
     )]
 
 

--- a/src/Exceptional/Highlightings/ExceptionNotDocumentedOptionalHighlighting.cs
+++ b/src/Exceptional/Highlightings/ExceptionNotDocumentedOptionalHighlighting.cs
@@ -1,22 +1,14 @@
 using System;
-using JetBrains.ReSharper.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
 using ReSharper.Exceptional;
 using ReSharper.Exceptional.Highlightings;
 using ReSharper.Exceptional.Models;
-
-#if R9 || R10
 using JetBrains.ReSharper.Feature.Services.Daemon;
-#endif
 
 [assembly: RegisterConfigurableSeverity(ExceptionNotDocumentedOptionalHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
     "Exceptional.ExceptionNotDocumentedOptional",
     "Exceptional.ExceptionNotDocumentedOptional",
     Severity.HINT
-#if !R2016_3 && !R2017_1
-    ,
-    false
-#endif
     )]
 
 

--- a/src/Exceptional/Highlightings/ExceptionNotThrownHighlighting.cs
+++ b/src/Exceptional/Highlightings/ExceptionNotThrownHighlighting.cs
@@ -1,22 +1,14 @@
 using System;
-using JetBrains.ReSharper.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
 using ReSharper.Exceptional;
 using ReSharper.Exceptional.Highlightings;
 using ReSharper.Exceptional.Models;
-
-#if R9 || R10
 using JetBrains.ReSharper.Feature.Services.Daemon;
-#endif
 
 [assembly: RegisterConfigurableSeverity(ExceptionNotThrownHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
     "Exceptional.ExceptionNotThrown",
     "Exceptional.ExceptionNotThrown",
     Severity.WARNING
-#if !R2016_3 && !R2017_1
-    ,
-    false
-#endif
     )]
 
 namespace ReSharper.Exceptional.Highlightings

--- a/src/Exceptional/Highlightings/ExceptionNotThrownOptionalHighlighting.cs
+++ b/src/Exceptional/Highlightings/ExceptionNotThrownOptionalHighlighting.cs
@@ -1,22 +1,14 @@
 using System;
-using JetBrains.ReSharper.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
 using ReSharper.Exceptional;
 using ReSharper.Exceptional.Highlightings;
 using ReSharper.Exceptional.Models;
-
-#if R9 || R10
 using JetBrains.ReSharper.Feature.Services.Daemon;
-#endif
 
 [assembly: RegisterConfigurableSeverity(ExceptionNotThrownOptionalHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
     "Exceptional.ExceptionNotThrownOptional",
     "Exceptional.ExceptionNotThrownOptional",
     Severity.HINT
-#if !R2016_3 && !R2017_1
-    ,
-    false
-#endif
     )]
 
 namespace ReSharper.Exceptional.Highlightings

--- a/src/Exceptional/Highlightings/HighlightingBase.cs
+++ b/src/Exceptional/Highlightings/HighlightingBase.cs
@@ -1,16 +1,6 @@
 using System;
-using JetBrains.ReSharper.Daemon;
-using JetBrains.ReSharper.Daemon.CSharp.Errors;
-using JetBrains.ReSharper.Psi.CSharp;
-using ReSharper.Exceptional;
-using ReSharper.Exceptional.Highlightings;
-using ReSharper.Exceptional.Models;
 using JetBrains.DocumentModel;
-
-#if R9 || R10
-using JetBrains.ReSharper.Feature.Services.CSharp.Daemon;
 using JetBrains.ReSharper.Feature.Services.Daemon;
-#endif
 
 namespace ReSharper.Exceptional.Highlightings
 {

--- a/src/Exceptional/Highlightings/ThrowFromCatchWithNoInnerExceptionHighlighting.cs
+++ b/src/Exceptional/Highlightings/ThrowFromCatchWithNoInnerExceptionHighlighting.cs
@@ -1,23 +1,13 @@
-using System;
-using JetBrains.ReSharper.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
 using ReSharper.Exceptional;
 using ReSharper.Exceptional.Highlightings;
-using ReSharper.Exceptional.Models;
 using ReSharper.Exceptional.Models.ExceptionsOrigins;
-
-#if R9 || R10
 using JetBrains.ReSharper.Feature.Services.Daemon;
-#endif
 
 [assembly: RegisterConfigurableSeverity(ThrowFromCatchWithNoInnerExceptionHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
     "Exceptional.ThrowFromCatchWithNoInnerException",
     "Exceptional.ThrowFromCatchWithNoInnerException",
     Severity.WARNING
-#if !R2016_3 && !R2017_1
-    ,
-    false
-#endif
     )]
 
 namespace ReSharper.Exceptional.Highlightings

--- a/src/Exceptional/Highlightings/ThrowingSystemExceptionHighlighting.cs
+++ b/src/Exceptional/Highlightings/ThrowingSystemExceptionHighlighting.cs
@@ -1,21 +1,13 @@
 using System;
-using JetBrains.ReSharper.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
 using ReSharper.Exceptional;
 using ReSharper.Exceptional.Highlightings;
-
-#if R9 || R10
 using JetBrains.ReSharper.Feature.Services.Daemon;
-#endif
 
 [assembly: RegisterConfigurableSeverity(ThrowingSystemExceptionHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
     "Exceptional.ThrowingSystemException",
     "Exceptional.ThrowingSystemException",
     Severity.SUGGESTION
-#if !R2016_3 && !R2017_1
-    ,
-    false
-#endif
     )]
 
 namespace ReSharper.Exceptional.Highlightings

--- a/src/Exceptional/Models/CatchClauseModel.cs
+++ b/src/Exceptional/Models/CatchClauseModel.cs
@@ -131,21 +131,12 @@ namespace ReSharper.Exceptional.Models
         {
             if (Node.ExceptionType == null)
                 return false;
-#if R9 || R10
 
-            bool hasConditionalClause = 
-#if !R2016_3 && !R2017_1
-            Node.ConditionClause?.WhenKeyword != null;
-#else
-            Node.Filter != null;
-#endif
+            bool hasConditionalClause = Node.Filter != null;
             bool rethrows = ContainsRethrowStatement(Node.Body);
             bool isSystemException = Node.ExceptionType.GetClrName().FullName == "System.Exception";
 
             return isSystemException && !hasConditionalClause && !rethrows;
-#else
-            return Node.ExceptionType.GetClrName().FullName == "System.Exception";
-#endif
         }
 
         private bool ContainsRethrowStatement(IBlock body)

--- a/src/Exceptional/Models/DocCommentBlockModel.cs
+++ b/src/Exceptional/Models/DocCommentBlockModel.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using JetBrains.Application.Progress;
-using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CodeStyle;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.ExtensionsAPI;
@@ -15,21 +14,11 @@ using ReSharper.Exceptional.Models.ExceptionsOrigins;
 namespace ReSharper.Exceptional.Models
 {
     /// <summary>Stores data about processed <see cref="IDocCommentBlockNode"/>. </summary>
-#if R8
-    internal class DocCommentBlockModel : TreeElementModelBase<IDocCommentBlockNode>
-#endif
-#if R9 || R10
     internal class DocCommentBlockModel : TreeElementModelBase<IDocCommentBlock>
-#endif
     {
         private string _documentationText;
 
-#if R8
-        public DocCommentBlockModel(IAnalyzeUnit analyzeUnit, IDocCommentBlockNode docCommentNode)
-#endif
-#if R9 || R10
         public DocCommentBlockModel(IAnalyzeUnit analyzeUnit, IDocCommentBlock docCommentNode)
-#endif
             : base(analyzeUnit, docCommentNode)
         {
             References = new List<IReference>();

--- a/src/Exceptional/Models/ExceptionDocCommentModel.cs
+++ b/src/Exceptional/Models/ExceptionDocCommentModel.cs
@@ -67,21 +67,13 @@ namespace ReSharper.Exceptional.Models
             var psiModule = DocumentationBlock.Node.GetPsiModule();
 
             if (exceptionReference == null)
-#if R10
                 return TypeFactory.CreateTypeByCLRName(exceptionType, psiModule);
-#else
-                return TypeFactory.CreateTypeByCLRName(exceptionType, psiModule, psiModule.GetContextFromModule());
-#endif
             else
             {
                 var resolveResult = exceptionReference.Resolve();
                 var declaredType = resolveResult.DeclaredElement as ITypeElement;
                 if (declaredType == null)
-#if R10
                     return TypeFactory.CreateTypeByCLRName(exceptionType, psiModule);
-#else
-                    return TypeFactory.CreateTypeByCLRName(exceptionType, psiModule, psiModule.GetContextFromModule());
-#endif
                 else
                     return TypeFactory.CreateType(declaredType);
             }

--- a/src/Exceptional/Models/ExceptionsOrigins/ConstructorInitializerModel.cs
+++ b/src/Exceptional/Models/ExceptionsOrigins/ConstructorInitializerModel.cs
@@ -23,11 +23,7 @@ namespace ReSharper.Exceptional.Models.ExceptionsOrigins
             ConstructorDeclarationModel containingBlock)
             : base(
                 analyzeUnit,
-#if R2017_1
                 analyzeUnit.Node.TypeName
-#else
-                analyzeUnit.Node.Name
-#endif
             )
         {
             ContainingBlock = containingBlock;

--- a/src/Exceptional/Models/ExceptionsOrigins/ReferenceExpressionModel.cs
+++ b/src/Exceptional/Models/ExceptionsOrigins/ReferenceExpressionModel.cs
@@ -81,11 +81,7 @@ namespace ReSharper.Exceptional.Models.ExceptionsOrigins
                     {
                         var psiModule = Node.GetPsiModule();
 
-#if R10
                         var delegateType = TypeFactory.CreateTypeByCLRName("System.Delegate", psiModule);
-#else
-                        var delegateType = TypeFactory.CreateTypeByCLRName("System.Delegate", psiModule, psiModule.GetContextFromModule());
-#endif
 
                         var type = Node.GetExpressionType().ToIType();
                         if (type != null)
@@ -138,11 +134,7 @@ namespace ReSharper.Exceptional.Models.ExceptionsOrigins
         {
             var psiModule = Node.GetPsiModule();
 
-#if R10
             var systemExceptionType = TypeFactory.CreateTypeByCLRName("System.Exception", psiModule);
-#else
-            var systemExceptionType = TypeFactory.CreateTypeByCLRName("System.Exception", psiModule, psiModule.GetContextFromModule());
-#endif
 
             string accessor = null;
             if (ContainingBlock is AccessorDeclarationModel)
@@ -174,11 +166,7 @@ namespace ReSharper.Exceptional.Models.ExceptionsOrigins
                     if (property != null)
                     {
                         var psiModule = Node.GetPsiModule();
-#if R10
                         var delegateType = TypeFactory.CreateTypeByCLRName("System.Delegate", psiModule);
-#else
-                        var delegateType = TypeFactory.CreateTypeByCLRName("System.Delegate", psiModule, psiModule.GetContextFromModule());
-#endif
                         return !property.Type.IsSubtypeOf(delegateType);
                     }
                     return false;

--- a/src/Exceptional/Models/ThrownExceptionsReader.cs
+++ b/src/Exceptional/Models/ThrownExceptionsReader.cs
@@ -3,9 +3,7 @@ using System.Linq;
 using System.Xml;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
-using JetBrains.ReSharper.Psi.Modules;
 using JetBrains.ReSharper.Psi.Tree;
-using JetBrains.Util.Logging;
 using ReSharper.Exceptional.Models.ExceptionsOrigins;
 
 namespace ReSharper.Exceptional.Models
@@ -36,16 +34,6 @@ namespace ReSharper.Exceptional.Models
 
             foreach (var declaration in declarations)
             {
-#if R8
-                var docCommentBlockOwnerNode = declaration as IDocCommentBlockOwnerNode;
-                if (docCommentBlockOwnerNode == null)
-                    return result;
-
-                var docCommentBlockNode = docCommentBlockOwnerNode.GetDocCommentBlockNode();
-                if (docCommentBlockNode == null)
-                    return result;
-#endif
-#if R9 || R10
                 var docCommentBlockOwnerNode = declaration as IDocCommentBlockOwner;
                 if (docCommentBlockOwnerNode == null)
                     return result;
@@ -53,7 +41,6 @@ namespace ReSharper.Exceptional.Models
                 var docCommentBlockNode = docCommentBlockOwnerNode.DocCommentBlock;
                 if (docCommentBlockNode == null)
                     return result;
-#endif
                 string accessor = null;
                 if (exceptionsOrigin is ReferenceExpressionModel &&
                     exceptionsOrigin.ContainingBlock is AccessorDeclarationModel)
@@ -133,11 +120,7 @@ namespace ReSharper.Exceptional.Models
                     if (exceptionType.StartsWith("T:"))
                         exceptionType = exceptionType.Substring(2);
 
-#if R10
                     var exceptionDeclaredType = TypeFactory.CreateTypeByCLRName(exceptionType, psiModule);
-#else
-                    var exceptionDeclaredType = TypeFactory.CreateTypeByCLRName(exceptionType, psiModule, psiModule.GetContextFromModule());
-#endif
 
                     result.Add(new ThrownExceptionModel(analyzeUnit, exceptionsOrigin, exceptionDeclaredType, 
                         exceptionNode.InnerXml, false, accessor));

--- a/src/Exceptional/QuickFixes/AddExceptionDocumentationFix.cs
+++ b/src/Exceptional/QuickFixes/AddExceptionDocumentationFix.cs
@@ -1,26 +1,15 @@
 using System;
-using JetBrains.Application;
 using JetBrains.Application.Progress;
 using JetBrains.DocumentModel;
 using JetBrains.ProjectModel;
-using JetBrains.ReSharper.Feature.Services.Bulbs;
 using JetBrains.ReSharper.Feature.Services.LiveTemplates.Hotspots;
 using JetBrains.ReSharper.Feature.Services.LiveTemplates.LiveTemplates;
-using JetBrains.ReSharper.LiveTemplates;
 using JetBrains.TextControl;
-using JetBrains.Util;
 using ReSharper.Exceptional.Highlightings;
 using ReSharper.Exceptional.Models;
-using ReSharper.Exceptional.Models.ExceptionsOrigins;
-
-#if R8
-using JetBrains.ReSharper.Intentions.Extensibility;
-#endif
-#if R9 || R10
 using JetBrains.ReSharper.Feature.Services.LiveTemplates.Templates;
 using JetBrains.ReSharper.Feature.Services.QuickFixes;
 using JetBrains.ReSharper.Resources.Shell;
-#endif
 
 namespace ReSharper.Exceptional.QuickFixes
 {

--- a/src/Exceptional/QuickFixes/CatchExceptionFix.cs
+++ b/src/Exceptional/QuickFixes/CatchExceptionFix.cs
@@ -1,16 +1,9 @@
 using System;
 using JetBrains.Application.Progress;
 using JetBrains.ProjectModel;
-using JetBrains.ReSharper.Feature.Services.Bulbs;
 using JetBrains.TextControl;
 using ReSharper.Exceptional.Highlightings;
-
-#if R8
-using JetBrains.ReSharper.Intentions.Extensibility;
-#endif
-#if R9 || R10
 using JetBrains.ReSharper.Feature.Services.QuickFixes;
-#endif
 
 namespace ReSharper.Exceptional.QuickFixes
 {

--- a/src/Exceptional/QuickFixes/IncludeInnerExceptionFix.cs
+++ b/src/Exceptional/QuickFixes/IncludeInnerExceptionFix.cs
@@ -1,18 +1,11 @@
 using System;
 using JetBrains.Application.Progress;
 using JetBrains.ProjectModel;
-using JetBrains.ReSharper.Feature.Services.Bulbs;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.TextControl;
 using ReSharper.Exceptional.Highlightings;
 using ReSharper.Exceptional.Utilities;
-
-#if R8
-using JetBrains.ReSharper.Intentions.Extensibility;
-#endif
-#if R9 || R10
 using JetBrains.ReSharper.Feature.Services.QuickFixes;
-#endif
 
 namespace ReSharper.Exceptional.QuickFixes
 {

--- a/src/Exceptional/QuickFixes/RemoveExceptionDocumentationFix.cs
+++ b/src/Exceptional/QuickFixes/RemoveExceptionDocumentationFix.cs
@@ -1,13 +1,9 @@
 using System;
 using JetBrains.Application.Progress;
 using JetBrains.ProjectModel;
-using JetBrains.ReSharper.Feature.Services.Bulbs;
 using JetBrains.TextControl;
 using ReSharper.Exceptional.Highlightings;
-
-#if R9 || R10
 using JetBrains.ReSharper.Feature.Services.QuickFixes;
-#endif
 
 namespace ReSharper.Exceptional.QuickFixes
 {

--- a/src/Exceptional/QuickFixes/SingleActionFix.cs
+++ b/src/Exceptional/QuickFixes/SingleActionFix.cs
@@ -1,11 +1,5 @@
 using JetBrains.Util;
-
-#if R8
-using JetBrains.ReSharper.Intentions.Extensibility;
-#endif
-#if R9 || R10
 using JetBrains.ReSharper.Feature.Services.QuickFixes;
-#endif
 
 namespace ReSharper.Exceptional.QuickFixes
 {

--- a/src/Exceptional/Settings/ExceptionAccessorOverride.cs
+++ b/src/Exceptional/Settings/ExceptionAccessorOverride.cs
@@ -30,12 +30,7 @@ namespace ReSharper.Exceptional.Settings
 
             try
             {
-#if R10
                 _exceptionType = TypeFactory.CreateTypeByCLRName(ExceptionType, ServiceLocator.StageProcess.PsiModule);
-#else
-                _exceptionType = TypeFactory.CreateTypeByCLRName(ExceptionType, 
-                    ServiceLocator.StageProcess.PsiModule, ServiceLocator.StageProcess.PsiModule.GetContextFromModule());
-#endif
             }
             catch (Exception ex)
             {

--- a/src/Exceptional/Settings/ExceptionalSettings.cs
+++ b/src/Exceptional/Settings/ExceptionalSettings.cs
@@ -184,12 +184,7 @@ System.Collections.Generic.Dictionary.Item,System.Collections.Generic.KeyNotFoun
                 var arr = line.Split(',');
                 if (arr.Length == 2)
                 {
-#if R10
                     var exceptionType = TypeFactory.CreateTypeByCLRName(arr[0], ServiceLocator.StageProcess.PsiModule);
-#else
-                    var exceptionType = TypeFactory.CreateTypeByCLRName(arr[0], 
-                        ServiceLocator.StageProcess.PsiModule, ServiceLocator.StageProcess.PsiModule.GetContextFromModule());
-#endif
 
                     OptionalExceptionReplacementType replacementType;
                     if (Enum.TryParse(arr[1], out replacementType))

--- a/src/Exceptional/Settings/OptionalMethodExceptionConfiguration.cs
+++ b/src/Exceptional/Settings/OptionalMethodExceptionConfiguration.cs
@@ -37,11 +37,7 @@ namespace ReSharper.Exceptional.Settings
 
             try
             {
-#if R10
                 _exceptionType = TypeFactory.CreateTypeByCLRName(ExceptionType, ServiceLocator.StageProcess.PsiModule);
-#else
-                _exceptionType = TypeFactory.CreateTypeByCLRName(ExceptionType, ServiceLocator.StageProcess.PsiModule, ServiceLocator.StageProcess.PsiModule.GetContextFromModule());
-#endif
             }
             catch (Exception ex)
             {

--- a/src/Exceptional/Utilities/CodeElementFactory.cs
+++ b/src/Exceptional/Utilities/CodeElementFactory.cs
@@ -37,16 +37,8 @@ namespace ReSharper.Exceptional.Utilities
 
             if (exceptionType != null)
             {
-#if R8
-                var declaredTypeUsageNode = _factory.CreateDeclaredTypeUsageNode(exceptionType);
-#else
                 var declaredTypeUsageNode = _factory.CreateTypeUsage(exceptionType, context);
-#endif
-#if R2016_3 || R2017_1
                 catchClause.SetExceptionTypeUsage(declaredTypeUsageNode);
-#else
-                exceptionDeclaration.SetDeclaredTypeUsage(declaredTypeUsageNode);
-#endif
             }
 
             return exceptionDeclaration;
@@ -86,17 +78,8 @@ namespace ReSharper.Exceptional.Utilities
                 if (exceptionDeclaration == null)
                     return null;
 
-#if R8
-                var declaredTypeUsageNode = _factory.CreateDeclaredTypeUsageNode(exceptionType);
-#else
                 var declaredTypeUsageNode = _factory.CreateTypeUsage(exceptionType, catchBody);
-
-#endif
-#if R2016_3 || R2017_1
                 catchClause.SetExceptionTypeUsage(declaredTypeUsageNode);
-#else
-                exceptionDeclaration.SetDeclaredTypeUsage(declaredTypeUsageNode);
-#endif
             }
 
             catchClause.SetBody(catchBody);
@@ -123,16 +106,8 @@ namespace ReSharper.Exceptional.Utilities
             if (exceptionDeclaration == null)
                 return tryStatement;
 
-#if R8
-            var declaredTypeUsageNode = _factory.CreateDeclaredTypeUsageNode(exceptionType);
-#else
             var declaredTypeUsageNode = _factory.CreateTypeUsage(exceptionType, context);
-#endif
-#if R2016_3 || R2017_1
             catchClause.SetExceptionTypeUsage(declaredTypeUsageNode);
-#else
-                exceptionDeclaration.SetDeclaredTypeUsage(declaredTypeUsageNode);
-#endif
 
             return tryStatement;
         }


### PR DESCRIPTION
Preprocessor directives no longer needed, because R# does no longer maintain backwards binary compatibility between major or minor releases (platform versioning)