### PR TITLE
Updated to SDK 2020.2.3, fixes #114

### DIFF
--- a/src/Exceptional/Exceptional.csproj
+++ b/src/Exceptional/Exceptional.csproj
@@ -55,15 +55,12 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations">
-      <Version>2019.1.3</Version>
-    </PackageReference>
-    <PackageReference Include="JetBrains.Lifetimes">
-      <Version>2019.3.0</Version>
+      <Version>2020.1.0</Version>
     </PackageReference>
     <PackageReference Include="JetBrains.RdFramework">
-      <Version>2019.3.0</Version>
+      <Version>2020.2.3</Version>
     </PackageReference>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.3.0">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2020.2.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Exceptional/Highlightings/CatchAllClauseHighlighting.cs
+++ b/src/Exceptional/Highlightings/CatchAllClauseHighlighting.cs
@@ -5,15 +5,15 @@ using ReSharper.Exceptional.Highlightings;
 
 using JetBrains.ReSharper.Feature.Services.Daemon;
 
-[assembly: RegisterConfigurableSeverity(CatchAllClauseHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
-    "Exceptional.CatchAllClause",
-    "Exceptional.CatchAllClause",
-    Severity.SUGGESTION
-    )]
 
 
 namespace ReSharper.Exceptional.Highlightings
 {
+    [RegisterConfigurableSeverity(Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
+        "Exceptional.CatchAllClause",
+        "Exceptional.CatchAllClause",
+        Severity.SUGGESTION
+    )]
     [ConfigurableSeverityHighlighting(Id, CSharpLanguage.Name)]
     public class CatchAllClauseHighlighting : HighlightingBase
     {

--- a/src/Exceptional/Highlightings/EventExceptionNotDocumentedHighlighting.cs
+++ b/src/Exceptional/Highlightings/EventExceptionNotDocumentedHighlighting.cs
@@ -5,15 +5,14 @@ using ReSharper.Exceptional.Models;
 
 using JetBrains.ReSharper.Feature.Services.Daemon;
 
-[assembly: RegisterConfigurableSeverity(EventExceptionNotDocumentedHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
-    "Exceptional.EventExceptionNotDocumented",
-    "Exceptional.EventExceptionNotDocumented",
-    Severity.SUGGESTION
-    )]
-
 
 namespace ReSharper.Exceptional.Highlightings
 {
+    [RegisterConfigurableSeverity(EventExceptionNotDocumentedHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
+        "Exceptional.EventExceptionNotDocumented",
+        "Exceptional.EventExceptionNotDocumented",
+        Severity.SUGGESTION
+    )]
     [ConfigurableSeverityHighlighting(Id, CSharpLanguage.Name)]
     public class EventExceptionNotDocumentedHighlighting : ExceptionNotDocumentedHighlighting
     {

--- a/src/Exceptional/Highlightings/ExceptionNotDocumentedHighlighting.cs
+++ b/src/Exceptional/Highlightings/ExceptionNotDocumentedHighlighting.cs
@@ -7,15 +7,13 @@ using ReSharper.Exceptional.Models;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 
 
-[assembly: RegisterConfigurableSeverity(ExceptionNotDocumentedHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
-    "Exceptional.ExceptionNotDocumented",
-    "Exceptional.ExceptionNotDocumented",
-    Severity.WARNING
-    )]
-
-
 namespace ReSharper.Exceptional.Highlightings
 {
+    [RegisterConfigurableSeverity(ExceptionNotDocumentedHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
+        "Exceptional.ExceptionNotDocumented",
+        "Exceptional.ExceptionNotDocumented",
+        Severity.WARNING
+    )]
     [ConfigurableSeverityHighlighting(Id, CSharpLanguage.Name)]
     public class ExceptionNotDocumentedHighlighting : ExceptionNotDocumentedOptionalHighlighting
     {

--- a/src/Exceptional/Highlightings/ExceptionNotDocumentedOptionalHighlighting.cs
+++ b/src/Exceptional/Highlightings/ExceptionNotDocumentedOptionalHighlighting.cs
@@ -5,16 +5,16 @@ using ReSharper.Exceptional.Highlightings;
 using ReSharper.Exceptional.Models;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 
-[assembly: RegisterConfigurableSeverity(ExceptionNotDocumentedOptionalHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
-    "Exceptional.ExceptionNotDocumentedOptional",
-    "Exceptional.ExceptionNotDocumentedOptional",
-    Severity.HINT
-    )]
 
 
 
 namespace ReSharper.Exceptional.Highlightings
 {
+    [RegisterConfigurableSeverity(ExceptionNotDocumentedOptionalHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
+        "Exceptional.ExceptionNotDocumentedOptional",
+        "Exceptional.ExceptionNotDocumentedOptional",
+        Severity.HINT
+    )]
     [ConfigurableSeverityHighlighting(Id, CSharpLanguage.Name)]
     public class ExceptionNotDocumentedOptionalHighlighting : HighlightingBase
     {

--- a/src/Exceptional/Highlightings/ExceptionNotThrownHighlighting.cs
+++ b/src/Exceptional/Highlightings/ExceptionNotThrownHighlighting.cs
@@ -5,14 +5,14 @@ using ReSharper.Exceptional.Highlightings;
 using ReSharper.Exceptional.Models;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 
-[assembly: RegisterConfigurableSeverity(ExceptionNotThrownHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
-    "Exceptional.ExceptionNotThrown",
-    "Exceptional.ExceptionNotThrown",
-    Severity.WARNING
-    )]
 
 namespace ReSharper.Exceptional.Highlightings
 {
+    [RegisterConfigurableSeverity(ExceptionNotThrownHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
+        "Exceptional.ExceptionNotThrown",
+        "Exceptional.ExceptionNotThrown",
+        Severity.WARNING
+    )]
     [ConfigurableSeverityHighlighting(Id, CSharpLanguage.Name)]
     public class ExceptionNotThrownHighlighting : ExceptionNotThrownOptionalHighlighting
     {

--- a/src/Exceptional/Highlightings/ExceptionNotThrownOptionalHighlighting.cs
+++ b/src/Exceptional/Highlightings/ExceptionNotThrownOptionalHighlighting.cs
@@ -5,14 +5,14 @@ using ReSharper.Exceptional.Highlightings;
 using ReSharper.Exceptional.Models;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 
-[assembly: RegisterConfigurableSeverity(ExceptionNotThrownOptionalHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
-    "Exceptional.ExceptionNotThrownOptional",
-    "Exceptional.ExceptionNotThrownOptional",
-    Severity.HINT
-    )]
 
 namespace ReSharper.Exceptional.Highlightings
 {
+    [RegisterConfigurableSeverity(ExceptionNotThrownOptionalHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
+        "Exceptional.ExceptionNotThrownOptional",
+        "Exceptional.ExceptionNotThrownOptional",
+        Severity.HINT
+    )]
     [ConfigurableSeverityHighlighting(Id, CSharpLanguage.Name)]
     public class ExceptionNotThrownOptionalHighlighting : HighlightingBase
     {

--- a/src/Exceptional/Highlightings/ThrowFromCatchWithNoInnerExceptionHighlighting.cs
+++ b/src/Exceptional/Highlightings/ThrowFromCatchWithNoInnerExceptionHighlighting.cs
@@ -4,14 +4,14 @@ using ReSharper.Exceptional.Highlightings;
 using ReSharper.Exceptional.Models.ExceptionsOrigins;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 
-[assembly: RegisterConfigurableSeverity(ThrowFromCatchWithNoInnerExceptionHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
-    "Exceptional.ThrowFromCatchWithNoInnerException",
-    "Exceptional.ThrowFromCatchWithNoInnerException",
-    Severity.WARNING
-    )]
 
 namespace ReSharper.Exceptional.Highlightings
 {
+    [RegisterConfigurableSeverity(ThrowFromCatchWithNoInnerExceptionHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
+        "Exceptional.ThrowFromCatchWithNoInnerException",
+        "Exceptional.ThrowFromCatchWithNoInnerException",
+        Severity.WARNING
+    )]
     [ConfigurableSeverityHighlighting(Id, CSharpLanguage.Name)]
     public class ThrowFromCatchWithNoInnerExceptionHighlighting : HighlightingBase
     {

--- a/src/Exceptional/Highlightings/ThrowingSystemExceptionHighlighting.cs
+++ b/src/Exceptional/Highlightings/ThrowingSystemExceptionHighlighting.cs
@@ -1,17 +1,14 @@
 using System;
-using JetBrains.ReSharper.Psi.CSharp;
-using ReSharper.Exceptional;
-using ReSharper.Exceptional.Highlightings;
 using JetBrains.ReSharper.Feature.Services.Daemon;
-
-[assembly: RegisterConfigurableSeverity(ThrowingSystemExceptionHighlighting.Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
-    "Exceptional.ThrowingSystemException",
-    "Exceptional.ThrowingSystemException",
-    Severity.SUGGESTION
-    )]
+using JetBrains.ReSharper.Psi.CSharp;
 
 namespace ReSharper.Exceptional.Highlightings
 {
+    [RegisterConfigurableSeverity(Id, Constants.CompoundName, HighlightingGroupIds.BestPractice,
+        "Exceptional.ThrowingSystemException",
+        "Exceptional.ThrowingSystemException",
+        Severity.SUGGESTION
+    )]
     [ConfigurableSeverityHighlighting(Id, CSharpLanguage.Name)]
     public class ThrowingSystemExceptionHighlighting : HighlightingBase
     {


### PR DESCRIPTION
Updated the library to 2020.2.3 SDK, fixes #114 

It seems `RegisterConfigurableSeverity` is not working on the assembly, it needs to be moved to be before class, otherwise compilation fails with `CS0592`, possible because `AttributeUsage` on the `RegisterConfigurableSeverityAttribute` class is only set to `AttributeTargets.Class`, fixed